### PR TITLE
Add new $contains comparator from spec v0.4

### DIFF
--- a/src/QueryExpressionFilter.php
+++ b/src/QueryExpressionFilter.php
@@ -115,7 +115,17 @@ class QueryExpressionFilter implements Filter
         } elseif ($comparator === '$in') {
             return in_array($actualValue, $expectedValue, true);
         } elseif ($comparator === '$contains') {
-            return (strpos($actualValue, $expectedValue) !== false);
+            if ($this->isObject($actualValue)) {
+                if (is_object($actualValue)) {
+                    return property_exists($actualValue, $expectedValue);
+                } else {
+                    return array_key_exists($expectedValue, $actualValue);
+                }
+            } elseif ($this->isVector($actualValue)) {
+                return in_array($expectedValue, $actualValue, true);
+            } else {
+                return (strpos($actualValue, $expectedValue) !== false);
+            }
         } elseif ($comparator === '$lt') {
             return ($actualValue < $expectedValue);
         } elseif ($comparator === '$lte') {

--- a/tests/QueryExpressionFilterTest.php
+++ b/tests/QueryExpressionFilterTest.php
@@ -349,6 +349,78 @@ class QueryExpressionFilterTest extends TestCase
         $this->assertTrue($filter->doesMatch(array('id' => 300)));
     }
 
+    public function testAttributeContainsString()
+    {
+        $filter = new QueryExpressionFilter(array(
+            'key' => array(
+                '$contains' => 'value'
+            )
+        ));
+
+        $this->assertTrue($filter->doesMatch(array(
+            'key' => 'the value exist'
+        )));
+        $this->assertFalse($filter->doesMatch(array(
+            'key' => 'empty'
+        )));
+    }
+
+    public function testAttributeContainsArray()
+    {
+        $filter = new QueryExpressionFilter(array(
+            'key' => array(
+                '$contains' => 'value'
+            )
+        ));
+
+        $this->assertTrue($filter->doesMatch(array(
+            'key' => array('the', 'value', 'exists')
+        )));
+        $this->assertFalse($filter->doesMatch(array(
+            'key' => array('not', 'present')
+        )));
+    }
+
+    public function testAttributeContainsAssoc()
+    {
+        $filter = new QueryExpressionFilter(array(
+            'key' => array(
+                '$contains' => 'value'
+            )
+        ));
+
+        $this->assertTrue($filter->doesMatch(array(
+            'key' => array(
+                'value' => 123
+            )
+        )));
+        $this->assertFalse($filter->doesMatch(array(
+            'key' => array(
+                'not' => 'present'
+            )
+        )));
+    }
+
+    public function testAttributeContainsObject()
+    {
+        $filter = new QueryExpressionFilter(array(
+            'key' => array(
+                '$contains' => 'value'
+            )
+        ));
+
+        $this->assertTrue($filter->doesMatch((object)array(
+            'key' => (object)array(
+                'value' => 123
+            )
+        )));
+        $this->assertFalse($filter->doesMatch((object)array(
+            'key' => (object)array(
+                'not' => 'present'
+            )
+        )));
+    }
+
     /**
      * @expectedException DomainException
      */


### PR DESCRIPTION
Spec v0.4 now defines a new `$contains` comparator: https://github.com/clue/json-query-language/blob/master/SYNTAX.md#contains-comparator

This PR supersedes and closes PR #6.
