### PR TITLE
Support root matching as defined in spec v0.4

### DIFF
--- a/src/QueryExpressionFilter.php
+++ b/src/QueryExpressionFilter.php
@@ -121,7 +121,7 @@ class QueryExpressionFilter implements Filter
         } elseif ($column[0] === '!') {
             return !$this->matchValue($data, substr($column, 1), $expectation);
         } elseif ($column[0] === '$') {
-            throw new DomainException('Unknown combinator "' . $column . '"');
+            return $this->matchComparator($data, $column, $expectation);
         }
 
         $expectedValue = $expectation;

--- a/tests/QueryExpressionFilterTest.php
+++ b/tests/QueryExpressionFilterTest.php
@@ -431,6 +431,45 @@ class QueryExpressionFilterTest extends TestCase
         )));
     }
 
+    public function testRootMatchingContainsAssoc()
+    {
+        $filter = new QueryExpressionFilter(array(
+            '$contains' => 'test'
+        ));
+
+        $this->assertTrue($filter->doesMatch(array(
+            'test' => true
+        )));
+        $this->assertTrue($filter->doesMatch(array(
+            'test' => false
+        )));
+        $this->assertTrue($filter->doesMatch(array(
+            'test' => null
+        )));
+
+        $this->assertFalse($filter->doesMatch(array(
+            'not' => 1
+        )));
+    }
+
+    public function testRootMatchingContainsArray()
+    {
+        $filter = new QueryExpressionFilter(array(
+            '$contains' => 'test'
+        ));
+
+        $this->assertTrue($filter->doesMatch(array(
+            'a',
+            'test'
+        )));
+
+        $this->assertFalse($filter->doesMatch(array(
+            'not'
+        )));
+        $this->assertFalse($filter->doesMatch(array(
+        )));
+    }
+
     /**
      * @expectedException DomainException
      */


### PR DESCRIPTION
See spec: https://github.com/clue/json-query-language/blob/master/SYNTAX.md#root-matching
