### PR TITLE
Support multiple operators as defined in spec v0.4

### DIFF
--- a/tests/QueryExpressionFilterTest.php
+++ b/tests/QueryExpressionFilterTest.php
@@ -470,6 +470,21 @@ class QueryExpressionFilterTest extends TestCase
         )));
     }
 
+    public function testMultipleOperators()
+    {
+        $filter = new QueryExpressionFilter(array(
+            'id' => array(
+                '$gte' => 100,
+                '$lt'  => 200
+            )
+        ));
+
+        $this->assertFalse($filter->doesMatch(array('id' => 99)));
+        $this->assertTrue($filter->doesMatch(array('id' => 100)));
+        $this->assertTrue($filter->doesMatch(array('id' => 199)));
+        $this->assertFalse($filter->doesMatch(array('id' => 200)));
+    }
+
     /**
      * @expectedException DomainException
      */


### PR DESCRIPTION
See spec: https://github.com/clue/json-query-language/blob/master/SYNTAX.md#l2-matching-multiple-operators
